### PR TITLE
Add 'void' to functions w/o arguments

### DIFF
--- a/swejpl.c
+++ b/swejpl.c
@@ -945,7 +945,7 @@ int swi_open_jpl_file(double *ss, char *fname, char *fpath, char *serr)
   return retc;
 }
 
-int32 swi_get_jpl_denum()
+int32 swi_get_jpl_denum(void)
 {
   return js->eh_denum;
 }

--- a/swemini.c
+++ b/swemini.c
@@ -23,7 +23,7 @@
 
 char *smon[] = {NULL, "January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"};
 
-int main()
+int main(void)
 {
   char sdate[AS_MAXCH], snam[40], serr[AS_MAXCH];  
   int jday = 1, jmon = 1, jyear = 2022;

--- a/swemmoon.c
+++ b/swemmoon.c
@@ -1179,7 +1179,7 @@ moonpol[1] *= a;
 moonpol[2] *= a;
 }
 #else
-static void moon1()
+static void moon1(void)
 {
 double a;
 /* This code added by Bhanu Pinnamaneni, 17-aug-2009 */
@@ -1364,7 +1364,7 @@ moonpol[2] *= a;
 }
 #endif	/* MOSH_MOON_200 */
 
-static void moon2()
+static void moon2(void)
 {
 /* terms in T^0 */
 g = STR*(2*(Ea-Ju+D)-MP+648431.172);
@@ -1441,7 +1441,7 @@ g = STR*(SWELP - 2.0*D + 2.5);
 B +=  0.29855 * sin(g);
 }
 
-static void moon3()
+static void moon3(void)
 {
 /* terms in T^0 */
 moonpol[0] = 0.0;
@@ -1455,7 +1455,7 @@ moonpol[2] = 1.0e-4 * moonpol[2] + 385000.52899; /* kilometers */
 
 /* Compute final ecliptic polar coordinates
  */
-static void moon4()
+static void moon4(void)
 {
 moonpol[2] /= AUNIT / 1000;
 moonpol[0] = STR * mods3600( moonpol[0] );
@@ -1760,7 +1760,7 @@ void swi_mean_lunar_elements(double tjd,
   *peri = swe_degnorm(*peri - dcor);
 }
 
-static void mean_elements()
+static void mean_elements(void)
 {
 double fracT = fmod(T, 1);
 /* Mean anomaly of sun = l' (J. Laskar) */
@@ -1817,7 +1817,7 @@ SWELP += ((z[11]*T + z[10])*T + z[9])*T2;
  */
 }
 
-void mean_elements_pl() 
+void mean_elements_pl(void)
 {
 /* Mean longitudes of planets (Laskar, Bretagnon) */
 Ve = mods3600( 210664136.4335482 * T + 655127.283046 );

--- a/sweph.c
+++ b/sweph.c
@@ -7266,7 +7266,7 @@ void CALL_CONV swe_set_topo(double geolon, double geolat, double geoalt)
   swi_force_app_pos_etc();
 }
 
-void swi_force_app_pos_etc()
+void swi_force_app_pos_etc(void)
 {
   int i;
   for (i = 0; i < SEI_NPLANETS; i++)

--- a/swephlib.c
+++ b/swephlib.c
@@ -3151,7 +3151,7 @@ static double adjust_for_tidacc(double ans, double Y, double tid_acc, double tid
 }
 
 /* returns tidal acceleration used in swe_deltat() and swe_deltat_ex() */
-double CALL_CONV swe_get_tid_acc()
+double CALL_CONV swe_get_tid_acc(void)
 {
   return swed.tid_acc;
 }
@@ -3183,7 +3183,7 @@ void CALL_CONV swe_set_delta_t_userdef(double dt)
   }
 }
 
-int32 swi_guess_ephe_flag()
+int32 swi_guess_ephe_flag(void)
 {
   int32 iflag = SEFLG_SWIEPH;
   /* if jpl file is open, assume SEFLG_JPLEPH */

--- a/swevents.c
+++ b/swevents.c
@@ -267,7 +267,7 @@ static int find_zero(double y00, double y11, double y2, double dx,
 static int find_maximum(double y00, double y11, double y2, double dx, 
 			double *dxret, double *yret);
 static void print_item(char *s, double t, double x, double elo, double mag);
-static int print_motab();
+static int print_motab(void);
 
 // from old swevents.c
 static char *hms(double x, int32 iflag);
@@ -1265,7 +1265,7 @@ l_phase:
   return OK;
 }
 
-static int print_motab()
+static int print_motab(void)
 {
   int i, j;
   printf("%d\n", prev_yout);


### PR DESCRIPTION
clang v15 with option `-Wstrict-prototypes` issues warnings for functions w/o arguments. And these warnings are being flagged for our R package swephR on CRAN. This is the patch i am using to keep the package on CRAN. Would be great if you could incorporate it.