### PR TITLE
Add pyswisseph to README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -168,6 +168,9 @@ found on Github https://github.com/cyjoelchen/php-sweph
 ## Perl-Version
 found on Github https://github.com/aloistr/perl-sweph
 
+## Python-Version
+found on Github https://github.com/astrorigin/pyswisseph
+
 ## Numerical Integrator
 the numerical integrator to prepare swisss ephemeris files is not in a state
 fit for publication.


### PR DESCRIPTION
[pyswisseph](https://github.com/astrorigin/pyswisseph) is a python version of swisseph, it's pretty popular, so can be added to the README.

PS: thank you for creating this amazing library! Let the stars and planets always shine your way.